### PR TITLE
fix: simplifying validation

### DIFF
--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -12,7 +12,7 @@ export const FfernFriendApiSchema = NameSchema.extend({
 
 export type FfernFriend = z.infer<typeof FfernFriendApiSchema>
 
-export const BaseShippingAddressSchema = NameSchema.extend({
+export const ShippingAddressSchema = NameSchema.extend({
   addressLineOne: z.string().min(1, { message: "Address is required" }),
   addressLineTwo: z.string().optional(),
   city: z.string().min(1, { message: "City is required" }),
@@ -23,46 +23,9 @@ export const BaseShippingAddressSchema = NameSchema.extend({
   }),
 })
 
-export const ShippingAddressSchema = BaseShippingAddressSchema.superRefine((data, ctx) => {
-  const usZipRegex = /^\d{5}(-\d{4})?$/
-  const gbPostcodeRegex = /^[A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}$/i
-  const nlPostcodeRegex = /^[1-9][0-9]{3} ?[A-Z]{2}$/i
-
-  let isValid = true
-  let errorMessage = ""
-  switch (data.country) {
-    case "US":
-      if (!usZipRegex.test(data.postcode)) {
-        isValid = false
-        errorMessage = "Please enter a valid 5 or 9-digit ZIP code"
-      }
-      break
-    case "GB":
-      if (!gbPostcodeRegex.test(data.postcode)) {
-        isValid = false
-        errorMessage = "Please enter a valid UK postcode (e.g., SW1A 0AA)"
-      }
-      break
-    case "NL":
-      if (!nlPostcodeRegex.test(data.postcode)) {
-        isValid = false
-        errorMessage = "Please enter a valid NL postcode (e.g., 1012 AB)"
-      }
-      break
-  }
-
-  if (!isValid) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: errorMessage,
-      path: ["postcode"],
-    })
-  }
-})
-
 export type ShippingAddress = z.infer<typeof ShippingAddressSchema>
 
-export const PostApiResponseSchema = BaseShippingAddressSchema.extend({
+export const PostApiResponseSchema = ShippingAddressSchema.extend({
   id: z.string(),
   createdAt: z.number().int().positive(),
   updatedAt: z.number().int().positive(),

--- a/pages/friends/[id].tsx
+++ b/pages/friends/[id].tsx
@@ -26,8 +26,6 @@ const FfernFriendPage = ({ initialData, id }: FfernFriendPageProps) => {
     formState: { errors, isValid },
     reset,
     control,
-    watch,
-    trigger,
   } = useForm<ShippingAddress>({
     resolver: zodResolver(ShippingAddressSchema),
     mode: "onTouched",
@@ -36,7 +34,6 @@ const FfernFriendPage = ({ initialData, id }: FfernFriendPageProps) => {
     },
   })
 
-  const country = watch("country")
 
   const { data, isError, error } = useQuery({
     queryKey: ["ffernFriend", id],
@@ -52,12 +49,6 @@ const FfernFriendPage = ({ initialData, id }: FfernFriendPageProps) => {
       setIsSuccess(true)
     },
   })
-
-  useEffect(() => {
-    if (country) {
-      trigger("postcode")
-    }
-  }, [country, trigger])
 
   useEffect(() => {
     if (data) {


### PR DESCRIPTION
The validation previously worked, checking the format of the postcode/zip code against individual validation rules for GB, US and NE formats but this affected the visual validation on the frontend as the postcode input defaulted to the error state as the United Kingdom is the default country value. 

Could be fixed possibly with useRef to check initial render.